### PR TITLE
add COMPOSE_PATH_SEPARATOR in .env.example to fix incorrect directory…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 COMPOSE_PROFILES=
+COMPOSE_PATH_SEPARATOR=:
 COMPOSE_FILE=docker-compose.yml:adguardhome/docker-compose.yml:tandoor/docker-compose.yml:joplin/docker-compose.yml
 USER_ID=1000
 GROUP_ID=1000


### PR DESCRIPTION
This will fix the error: `CreateFile C:\server\nas\docker-compose.yml:adguardhome\docker-compose.yml: The filename, directory name, or volume label syntax is incorrect.` when running `docker compose up -d`