### PR TITLE
Avoid hardcoding credentials for pia forwarding on qbittorrent

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -221,7 +221,6 @@ services:
       - traefik.http.middlewares.jellyseerr-rewrite.plugin.rewrite-body.rewrites[14].replacement="/jellyseerr/$1/".concat
       - traefik.http.middlewares.jellyseerr-rewrite.plugin.rewrite-body.rewrites[15].regex=url:"/([/a-zA-Z?=]*)"
       - traefik.http.middlewares.jellyseerr-rewrite.plugin.rewrite-body.rewrites[15].replacement=url:"/jellyseerr/$1"
-      
       - homepage.group=Media
       - homepage.name=JellySeerr
       - homepage.icon=jellyseerr.png
@@ -336,6 +335,8 @@ services:
       - LOC=${PIA_LOCATION}
       - USER=${PIA_USER}
       - PASS=${PIA_PASS}
+      - QBT_USER=${QBITTORRENT_USERNAME}
+      - QBT_PASS=${QBITTORRENT_PASSWORD}
       - LOCAL_NETWORK=${PIA_LOCAL_NETWORK}
       - PORT_FORWARDING=1
       - PORT_PERSIST=1

--- a/pia-shared/portupdate-qbittorrent.sh
+++ b/pia-shared/portupdate-qbittorrent.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
 port="$1"
-QBT_USER=admin
-QBT_PASS=adminadmin
 QBT_PORT=8080
 
 echo "Setting qBittorrent port settings ($port)..."


### PR DESCRIPTION
This changes makes it so the port forward script will pull your qbittorrent credentials from the environment rather than explicitly hardcoding them in the script.
Also removes an accidental extra line that was added by my last pull request.