### PR TITLE
Update Script to Allowlist QBittorrent Instead of Attempting to Use Password

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,10 +294,6 @@ services:
       test: [ "CMD", "curl", "--fail", "http://127.0.0.1:8080", "https://google.com" ]
       interval: 30s
       retries: 10
-    network_mode: "service:vpn"
-    depends_on:
-      vpn:
-        condition: service_healthy
     labels:
       - traefik.enable=true
       - traefik.http.routers.qbittorrent.rule=(Host(`${HOSTNAME}`) && PathPrefix(`/qbittorrent`))
@@ -319,42 +315,7 @@ services:
       - homepage.description=Bittorrent client
       - homepage.weight=2
       - homepage.widget.type=qbittorrent
-      - homepage.widget.url=http://vpn:8080
-      - homepage.widget.username=${QBITTORRENT_USERNAME}
-      - homepage.widget.password=${QBITTORRENT_PASSWORD}
-  vpn:
-    image: thrnz/docker-wireguard-pia
-    container_name: vpn
-    volumes:
-      - ${CONFIG_ROOT:-.}/pia:/pia
-      - ${CONFIG_ROOT:-.}/pia-shared:/pia-shared
-    cap_add:
-      - NET_ADMIN
-      - SYS_MODULE
-    environment:
-      - LOC=${PIA_LOCATION}
-      - USER=${PIA_USER}
-      - PASS=${PIA_PASS}
-      - QBT_USER=${QBITTORRENT_USERNAME}
-      - QBT_PASS=${QBITTORRENT_PASSWORD}
-      - LOCAL_NETWORK=${PIA_LOCAL_NETWORK}
-      - PORT_FORWARDING=1
-      - PORT_PERSIST=1
-      - PORT_SCRIPT=/pia-shared/portupdate-qbittorrent.sh
-    sysctls:
-      - net.ipv4.conf.all.src_valid_mark=1
-      - net.ipv6.conf.default.disable_ipv6=1
-      - net.ipv6.conf.all.disable_ipv6=1
-      - net.ipv6.conf.lo.disable_ipv6=1
-    healthcheck:
-      test: ping -c 1 www.google.com || exit 1
-      interval: 30s
-      timeout: 10s
-      retries: 3
-    restart: always
-    labels:
-      # network mode is not supported: https://github.com/containrrr/watchtower/issues/1286#issuecomment-1214291660
-      - com.centurylinklabs.watchtower.enable=false
+      - homepage.widget.url=http://qbittorrent:8080
   unpackerr:
     image: golift/unpackerr
     container_name: unpackerr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -294,6 +294,10 @@ services:
       test: [ "CMD", "curl", "--fail", "http://127.0.0.1:8080", "https://google.com" ]
       interval: 30s
       retries: 10
+    network_mode: "service:vpn"
+    depends_on:
+      vpn:
+        condition: service_healthy
     labels:
       - traefik.enable=true
       - traefik.http.routers.qbittorrent.rule=(Host(`${HOSTNAME}`) && PathPrefix(`/qbittorrent`))
@@ -315,7 +319,42 @@ services:
       - homepage.description=Bittorrent client
       - homepage.weight=2
       - homepage.widget.type=qbittorrent
-      - homepage.widget.url=http://qbittorrent:8080
+      - homepage.widget.url=http://vpn:8080
+      - homepage.widget.username=${QBITTORRENT_USERNAME}
+      - homepage.widget.password=${QBITTORRENT_PASSWORD}
+  vpn:
+    image: thrnz/docker-wireguard-pia
+    container_name: vpn
+    volumes:
+      - ${CONFIG_ROOT:-.}/pia:/pia
+      - ${CONFIG_ROOT:-.}/pia-shared:/pia-shared
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    environment:
+      - LOC=${PIA_LOCATION}
+      - USER=${PIA_USER}
+      - PASS=${PIA_PASS}
+      - QBT_USER=${QBITTORRENT_USERNAME}
+      - QBT_PASS=${QBITTORRENT_PASSWORD}
+      - LOCAL_NETWORK=${PIA_LOCAL_NETWORK}
+      - PORT_FORWARDING=1
+      - PORT_PERSIST=1
+      - PORT_SCRIPT=/pia-shared/portupdate-qbittorrent.sh
+    sysctls:
+      - net.ipv4.conf.all.src_valid_mark=1
+      - net.ipv6.conf.default.disable_ipv6=1
+      - net.ipv6.conf.all.disable_ipv6=1
+      - net.ipv6.conf.lo.disable_ipv6=1
+    healthcheck:
+      test: ping -c 1 www.google.com || exit 1
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    restart: always
+    labels:
+      # network mode is not supported: https://github.com/containrrr/watchtower/issues/1286#issuecomment-1214291660
+      - com.centurylinklabs.watchtower.enable=false
   unpackerr:
     image: golift/unpackerr
     container_name: unpackerr

--- a/pia-shared/portupdate-qbittorrent.sh
+++ b/pia-shared/portupdate-qbittorrent.sh
@@ -4,14 +4,6 @@ port="$1"
 QBT_PORT=8080
 
 echo "Setting qBittorrent port settings ($port)..."
-# Very basic retry logic so we don't fail if qBittorrent isn't running yet
- while ! curl --silent --retry 10 --retry-delay 15 --max-time 10 \
-  --data "username=${QBT_USER}&password=${QBT_PASS}" \
-  --cookie-jar /tmp/qb-cookies.txt \
-  http://localhost:${QBT_PORT}/api/v2/auth/login
-  do
-    sleep 10
-  done
 
 curl --silent --retry 10 --retry-delay 15 --max-time 10 \
   --data 'json={"listen_port": "'"$port"'"}' \

--- a/update-config.sh
+++ b/update-config.sh
@@ -14,9 +14,12 @@ function update_arr_config {
 
 function update_qbittorrent_config {
     echo "Updating ${container} configuration..."
+    QBITTORRENT_SUBNET=$(docker network inspect -f '{{ (index .IPAM.Config 0).Subnet }}' docker-compose-nas)
     docker compose stop "$container"
     until [ -f "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf ]; do sleep 1; done
-    sed -i.bak '/WebUI\\ServerDomains=*/a WebUI\\Password_PBKDF2="@ByteArray(ARQ77eY1NUZaQsuDHbIMCA==:0WMRkYTUWVT9wVvdDtHAjU9b3b7uB8NR1Gur2hmQCvCDpm39Q+PsJRJPaCU51dEiz+dTzh8qbPsL8WkFljQYFQ==)"' "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf && rm "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf.bak
+    echo "WebUI\AuthSubnetWhitelist=${QBITTORRENT_SUBNET}" >> "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf
+    echo "WebUI\AuthSubnetWhitelistEnabled=true" >> "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf
+    echo "WebUI\HostHeaderValidation=false" >> "${CONFIG_ROOT:-.}"/"$container"/qBittorrent/qBittorrent.conf
     echo "Update of ${container} configuration complete, restarting..."
     docker compose start "$container"
 }


### PR DESCRIPTION
Using a salted password will not work because presumably every client download has a different salt. This is why the previous default wouldn't work even if we write the password to the .conf file.

This instead adds the subnet of the docker network to the conf file.