### PR TITLE
Fix vpn pia service issue with firewall 

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -354,6 +354,7 @@ services:
       - PORT_FORWARDING=1
       - PORT_PERSIST=1
       - PORT_SCRIPT=/pia-shared/portupdate-qbittorrent.sh
+      - FIREWALL=0
     sysctls:
       - net.ipv4.conf.all.src_valid_mark=1
       - net.ipv6.conf.default.disable_ipv6=1


### PR DESCRIPTION
# Disable firewall in PIA VPN container

This PR explicitly sets `FIREWALL=0` in the VPN service environment variables to maintain compatibility with the latest version of the `docker-wireguard-pia` image.

## Details
- In previous versions, the firewall was disabled by default
- Recent updates to the image have changed the default to enabled
- This was causing connectivity issues between containers
- Setting `FIREWALL=0` restores the previous behavior

Fixes issue described in: [docker-wireguard-pia#139](https://github.com/thrnz/docker-wireguard-pia/issues/139)