### PR TITLE
Add HOMEPAGE_ALLOWED_HOSTS in homepage environment vars

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -526,6 +526,7 @@ services:
       - HOMEPAGE_VAR_WEATHER_LONG=${HOMEPAGE_VAR_WEATHER_LONG}
       - HOMEPAGE_VAR_WEATHER_TIME=${TIMEZONE}
       - HOMEPAGE_VAR_WEATHER_UNIT=${HOMEPAGE_VAR_WEATHER_UNIT}
+      - HOMEPAGE_ALLOWED_HOSTS=${HOSTNAME}
     volumes:
       - ${CONFIG_ROOT:-.}/homepage:/app/config
       - /var/run/docker.sock:/var/run/docker.sock:ro


### PR DESCRIPTION
https://github.com/gethomepage/homepage/blob/dev/docs/installation/index.md#homepage_allowed_hosts

HOMEPAGE_ALLOWED_HOSTS
As of v1.0 there is one required environment variable when deploying via a public URL, HOMEPAGE_ALLOWED_HOSTS. This is a comma separated (no spaces) list of allowed hosts (sometimes with the port) that can access your homepage. See the [docker](https://github.com/gethomepage/homepage/blob/dev/docs/installation/docker.md) and [source](https://github.com/gethomepage/homepage/blob/dev/docs/installation/source.md) installation pages for examples.

