### PR TITLE
PR for Privoxy (Prowlarr reverse proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,6 @@
 COMPOSE_PROFILES=
 COMPOSE_PATH_SEPARATOR=:
-COMPOSE_FILE=docker-compose.yml:adguardhome/docker-compose.yml:tandoor/docker-compose.yml:joplin/docker-compose.yml:homeassistant/docker-compose.yml:immich/docker-compose.yml:vaultwarden/docker-compose.yml
+COMPOSE_FILE=docker-compose.yml:adguardhome/docker-compose.yml:tandoor/docker-compose.yml:joplin/docker-compose.yml:homeassistant/docker-compose.yml:immich/docker-compose.yml:vaultwarden/docker-compose.yml:privoxy/docker-compose.yml
 USER_ID=1000
 GROUP_ID=1000
 TIMEZONE="America/New_York"

--- a/privoxy/README.md
+++ b/privoxy/README.md
@@ -1,7 +1,13 @@
-Simple HTTP/S reverse proxy for Prowlarr (and other *ARR apps) using the already existing VPN container.
-Only tested with PIA VPN, other modifications might be necessary depending on your setup.
+# Privoxy
+
+[Privoxy](https://www.privoxy.org) is a simple HTTP/S reverse proxy for Prowlarr and other *arr apps using the already existing VPN container.  
+Tested with PIA VPN, other modifications might be necessary depending on your provider.  
 
 
-To enable it on Prowlarr, head to Settings > Indexers > Http 
-And add "vpn" as host, 8118 as port, give it a tag/label, then click on "test".
-Once working, add the tag/label to each indexer to proxy your connection through the VPN/VPN container.
+## Installation
+
+Enable Privoxy by setting `COMPOSE_PROFILES=privoxy`.  
+
+To enable it on Prowlarr, head to Settings > Indexers > Http.  
+Add "vpn" as host, 8118 as port, give it a tag/label, then click on "test".  
+Once working, add the tag/label to each indexer to proxy your connection through the VPN/VPN container.  

--- a/privoxy/README.md
+++ b/privoxy/README.md
@@ -1,0 +1,7 @@
+Simple HTTP/S reverse proxy for Prowlarr (and other *ARR apps) using the already existing VPN container.
+Only tested with PIA VPN, other modifications might be necessary depending on your setup.
+
+
+To enable it on Prowlarr, head to Settings > Indexers > Http 
+And add "vpn" as host, 8118 as port, give it a tag/label, then click on "test".
+Once working, add the tag/label to each indexer to proxy your connection through the VPN/VPN container.

--- a/privoxy/docker-compose.yml
+++ b/privoxy/docker-compose.yml
@@ -1,0 +1,17 @@
+services:
+  privoxy:
+    image: vimagick/privoxy
+    container_name: privoxy
+    network_mode: "service:vpn"
+    restart: always
+    healthcheck:
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8118"]
+      interval: 30s
+      retries: 5
+      start_period: 10s
+      timeout: 5s
+    depends_on:
+      vpn:
+        condition: service_healthy
+    profiles:
+      - privoxy


### PR DESCRIPTION
Hi,
As I had mentioned in a previous issue, there's a simple and straightforward way to forward VPN traffic through prowlarr without wrapping the container itself, thanks to privoxy/tinyproxy and by forwarding indexer requests through it.

Originally, i was using tinyproxy but it has some issues with HTTPS. Privoxy seems a better choice and is often recommended in *arr discord servers, and also allows for SOCK connections (which i haven't tested yet).

Would you let me know if it's something you'd be interested in adding? And if all the files/configurations are in the right place, as this is the first time I work with docker compose in such a way. As well as if you notice any issue with PIA/privoxy instead of regular behaviour.

Thank you


