### PR TITLE
corrected docs typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ see [Optional Services](#optional-services) for more information.
 
 ## Quick Start
 
-`cp .env.example .env`, edit to your needs then `docker compose up -d`.
+`cp .env.example .env`, edit to your needs then `docker-compose up -d`.
 
 For the first time, run `./update-config.sh` to update the applications base URLs and set the API keys in `.env`.
 


### PR DESCRIPTION
afaik (and from the docer version on the latest ubuntu server) there is no "docker compose" command, but instead "docker-compose"